### PR TITLE
BUG: fix kdeplot to allow use of fill=True after seaborn updates

### DIFF
--- a/geoplot/geoplot.py
+++ b/geoplot/geoplot.py
@@ -1304,7 +1304,7 @@ def kdeplot(
                 sns.kdeplot(
                     x=pd.Series([p.x for p in self.df.geometry]),
                     y=pd.Series([p.y for p in self.df.geometry]),
-                    transform=ccrs.PlateCarree(), ax=ax, **self.kwargs
+                    transform=ccrs.PlateCarree()._as_mpl_transform(ax), ax=ax, **self.kwargs
                 )
             else:
                 sns.kdeplot(

--- a/tests/test_geoplot.py
+++ b/tests/test_geoplot.py
@@ -1,0 +1,14 @@
+import geopandas as gpd
+import geoplot as gplt
+import geoplot.crs as gcrs
+import matplotlib.pyplot as plt
+import pytest
+
+
+def test_kdeplot_projection_when_shade_true():
+    boston_airbnb_listings = gpd.read_file(gplt.datasets.get_path('boston_airbnb_listings'))
+
+    ax = gplt.kdeplot(
+        boston_airbnb_listings, cmap='viridis', projection=gcrs.WebMercator(), figsize=(12, 12),
+        fill=True
+    )


### PR DESCRIPTION
Resolves #1 in this repo, duplicated issue from #289 in ResidentMario GeoPlot repo